### PR TITLE
change connectionTypes and fix bugs associated with this

### DIFF
--- a/src/applicationLayer/BlockController.java
+++ b/src/applicationLayer/BlockController.java
@@ -37,9 +37,8 @@ public class BlockController implements GUISubject, DomainSubject {
 		
 	}
 
-	private void fireBlockAdded() {
-		String blockId = BlockIDGenerator.getInstance().getLastGeneratedBlockId();
-		BlockAddedEvent event = new BlockAddedEvent(blockId);
+	private void fireBlockAdded(String newBlockId) {
+		BlockAddedEvent event = new BlockAddedEvent(newBlockId);
 		
 		for(GUIListener listener:guiListeners) {
 			listener.onBlockAdded(event);
@@ -113,7 +112,7 @@ public class BlockController implements GUISubject, DomainSubject {
 		if(programBlockRepository.checkIfMaxNbOfBlocksReached()) {
 			throw new MaxNbOfBlocksReachedException("The maximum number of blocks has already been reached.");
 		}
-		programBlockRepository.addBlock(blockType, connectedBlockId, connection);
+		String newBlockId= programBlockRepository.addBlock(blockType, connectedBlockId, connection);
 		
 		
 		fireUpdateGameState();
@@ -121,7 +120,7 @@ public class BlockController implements GUISubject, DomainSubject {
 		if(programBlockRepository.checkIfMaxNbOfBlocksReached()) {
 			firePanelChangedEvent();
 		}
-		fireBlockAdded();
+		fireBlockAdded(newBlockId);
 	}
 
 	/**

--- a/src/applicationLayer/ConnectionType.java
+++ b/src/applicationLayer/ConnectionType.java
@@ -8,7 +8,8 @@ package applicationLayer;
 public enum ConnectionType {
 	UP,
 	DOWN,
-	RIGHT,
+	OPERAND,
+	LEFT,
 	CONDITION,
 	BODY,
 	NOCONNECTION

--- a/src/applicationLayer/DomainController.java
+++ b/src/applicationLayer/DomainController.java
@@ -1,6 +1,7 @@
 package applicationLayer;
 
 import java.util.Collection;
+import java.util.Set;
 
 import domainLayer.blocks.BlockType;
 import events.GUIListener;
@@ -93,6 +94,17 @@ public class DomainController {
 		// TODO - implement DomainController.resetGameExecution
 		throw new UnsupportedOperationException();
 	}
+	
+	
+	
+	
+	public Set<String> getAllBlockIdsInBody(String blockId){
+		
+		
+		return null;
+	}
+
+
 
 	/**
 	 * 

--- a/src/domainLayer/blocks/Block.java
+++ b/src/domainLayer/blocks/Block.java
@@ -35,13 +35,7 @@ public abstract class Block {
 	 *                                         connection is not provided.
 	 */
 	public final void setOperand(Block block) {
-		if (!(block instanceof AssessableBlock)) {
-			throw new InvalidBlockConnectionException("This block is no AssessableBlock.");
-		} else {
-
-			this.setOperand((AssessableBlock) block);
-
-		}
+		parseToValidOperation(block);
 	}
 
 	/**
@@ -101,14 +95,28 @@ public abstract class Block {
 	 *                                         block of which the required
 	 *                                         connection is not provided.
 	 */
-	public final void setConditionBlock(Block block) {
+	public final void setConditionBlock(Block block) {		
+		parseToValidOperation(block);
+
+	}
+
+	private void parseToValidOperation(Block block) {
 		if (!(block instanceof AssessableBlock)) {
 			throw new InvalidBlockConnectionException("This block is no AssessableBlock.");
 		} else {
-			this.setConditionBlock((AssessableBlock) block);
+			if(this instanceof ControlBlock) {
+				this.setConditionBlock((AssessableBlock) block);
+			}
+			else if(this instanceof OperatorBlock) {				
+				this.setOperand((AssessableBlock) block);
+			}
+			else {
+				throw new InvalidBlockConnectionException("The connected block doesn't have the requested connection.");
+			}
 		}
-
 	}
+	
+	
 
 	/**
 	 * Set the operand connection to the given block.

--- a/src/domainLayer/blocks/BlockIDGenerator.java
+++ b/src/domainLayer/blocks/BlockIDGenerator.java
@@ -16,15 +16,7 @@ public class BlockIDGenerator {
 		this.id = -1;
 	}
 
-	/**
-	 * Retrieve the last generated blockID
-	 * @return the last generated blockID
-	 */
-	public String getLastGeneratedBlockId() {
-		return id.toString();
-	}
-	
-	
+
 	/**
 	 * Generate a new BlockID and return it
 	 * @return A unique newly generated BlockID


### PR DESCRIPTION
The connectionTypes needed to be changed because there was no way to add a block left of a conditonBlock for example.

There were also changes regarding the api of the domainController,
the signature public Set<String> getAllBlockIdsInBody(String blockId) was added but not implemented.

In the BlockRepository all Crud methods now return the id's of the blocks that were affected by their operation. As that the domainController is able to use these id's for events etc.

The getLastGeneratedBlockID from the BlockIDGenerator has been removed.

#11 
